### PR TITLE
Use PSR 7 Request and Response objects

### DIFF
--- a/layer/runtime.php
+++ b/layer/runtime.php
@@ -37,24 +37,19 @@ while (true) {
         continue;
     }
 
-    //Process the events
-    $eventPayload = $lambdaRuntime->getEventPayload();
-
     try {
         //Handler is a reference to a class that implements RequestHandlerInterface
         $handler = new $handlerClass();
 
         if ($handler instanceof RequestHandlerInterface) {
-            $lambdaPSR7Mapper = new LambdaPSR7Mapper();
-
-            $request = $lambdaPSR7Mapper->mapLambdaRequestToPSR7ServerRequest($eventPayload, $data);
+            $request = LambdaPSR7Mapper::mapLambdaRequestToPSR7ServerRequest($data);
 
             //Execute handler
             /** @var ResponseInterface $response */
             $response = $handler->handle($request);
 
             $lambdaRuntime->addToResponse(
-                $lambdaPSR7Mapper->mapPSR7ResponseToLambdaResponse($response)
+                LambdaPSR7Mapper::mapPSR7ResponseToLambdaResponse($response)
             );
         }
     } catch (Throwable $e) {

--- a/layer/src/LambdaPSR7Mapper.php
+++ b/layer/src/LambdaPSR7Mapper.php
@@ -5,46 +5,96 @@ namespace CEmerson\Sevenambda\Layer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Stream;
 use Zend\Diactoros\Uri;
 
 class LambdaPSR7Mapper
 {
-    private $eventPayload;
-    private $data;
+    private static $data;
 
-    public function mapLambdaRequestToPSR7ServerRequest($eventPayload, $data): ServerRequestInterface
+    public static function mapLambdaRequestToPSR7ServerRequest($data): ServerRequestInterface
     {
-        $this->eventPayload = json_decode($eventPayload);
-        $this->data = $data;
+        self::$data = $data;
+        $event = json_decode($data['body'], true);
 
         $uri = new Uri(
-            $this->eventPayload->requestContext->domainName . $this->eventPayload->requestContext->path
+            $event['headers']['X-Forwarded-Proto']
+            . '://'
+            . $event['requestContext']['domainName']
+            . $event['requestContext']['path']
         );
 
+        $bodyStream = fopen('php://memory','rb+');
+        fwrite($bodyStream, $event['body'] ?? '');
+        rewind($bodyStream);
+
+        $headers = $event['headers'];
+        $cookies = [];
+
+        foreach ($headers as $headerName => $value) {
+            if ($headerName === "Cookie") {
+                $cookieStrings = array_map('trim', explode(';', $value));
+
+                foreach ($cookieStrings as $cookieString) {
+                    $equalsSignPosition = strpos($cookieString, '=');
+
+                    $name = substr($cookieString, 0, $equalsSignPosition);
+                    $value = substr($cookieString, $equalsSignPosition + 1);
+
+                    $cookies[$name] = $value;
+                }
+            }
+        }
+
+        $queryStringParams = [];
+
+        if (count($event['queryStringParameters']) > 1) {
+            $queryString = implode('&', array_map(
+                function($key, $value) {
+                    return $key . '=' . $value;
+                },
+                array_keys($event['queryStringParameters']),
+                array_values($event['queryStringParameters'])
+            ));
+
+            parse_str($queryString, $queryStringParams);
+        }
+
+        $protocol = substr($event['requestContext']['protocol'], 5);
+
         $serverRequest = new ServerRequest(
-            [],
+            $event['requestContext'],
             [],
             $uri,
-            $this->eventPayload->httpMethod
+            $event['httpMethod'],
+            new Stream($bodyStream),
+            $event['headers'],
+            $cookies,
+            $queryStringParams,
+            null,
+            $protocol
         );
 
         return $serverRequest;
     }
 
-    public function mapPSR7ResponseToLambdaResponse(ResponseInterface $response): string
+    public static function mapPSR7ResponseToLambdaResponse(ResponseInterface $response): string
     {
-        $info = [
-            'eventPayload' => $this->eventPayload,
-            'data' => $this->data
-        ];
+        $response = $response->withAddedHeader('Content-Type', 'text/html');
 
-        $response->getBody()->write(json_encode($info, JSON_HEX_TAG));
+        $headers = [];
+
+        foreach ($response->getHeaders() as $headerName => $headerValue) {
+            $headers[$headerName] = $response->getHeaderLine($headerName);
+        }
+
         $response->getBody()->rewind();
 
         return json_encode([
             'statusCode' => $response->getStatusCode(),
+            'headers' => $headers,
             'body' => $response->getBody()->getContents(),
             'isBase64Encoded' => false
-        ]);
+        ], JSON_HEX_TAG);
     }
 }

--- a/layer/src/LambdaRuntime.php
+++ b/layer/src/LambdaRuntime.php
@@ -33,8 +33,6 @@ final class LambdaRuntime
 
     private $rawEventData;
 
-    private $eventPayload;
-
     /** @var string */
     private $handler;
 
@@ -59,14 +57,6 @@ final class LambdaRuntime
     public function getHandler(): string
     {
         return $this->handler;
-    }
-
-    /**
-     * Get the current event payload
-     */
-    public function getEventPayload(): string
-    {
-        return $this->eventPayload;
     }
 
     /**
@@ -123,7 +113,6 @@ final class LambdaRuntime
         }
 
         $this->requestId = $this->rawEventData['headers']['lambda-runtime-aws-request-id'][0];
-        $this->eventPayload = $this->rawEventData['body'];
 
         return $this->rawEventData;
     }


### PR DESCRIPTION
Create PSR-7 request object from Lambda event data, and convert PSR-7 Response back into JSON that Lambda needs to send.

Still doesn't properly parse query string params with multi-dimensional nesting. Needs looking at.